### PR TITLE
modified LCA function

### DIFF
--- a/shogun/__main__.py
+++ b/shogun/__main__.py
@@ -9,7 +9,7 @@ import logging
 from datetime import date
 from multiprocessing import cpu_count
 import click
-from yaml import load
+import yaml
 import pandas as pd
 
 from shogun import __version__, logger
@@ -306,7 +306,7 @@ def _load_metadata(database):
         with open(metadata_file, 'r') as stream:
             logger.debug(
                 "Attempting to load the database metadata file at %s" % (os.path.abspath(metadata_file)))
-            data_files = load(stream)
+            data_files = yaml.load(stream, Loader=yaml.SafeLoader)
         return data_files
     else:
         logger.critical("Unable to load database at %s" % os.path.abspath(metadata_file))

--- a/shogun/aligners/_aligner.py
+++ b/shogun/aligners/_aligner.py
@@ -6,7 +6,7 @@ This software is released under the GNU Affero General Public License (AGPL) v3.
 
 import os
 
-from yaml import load
+import yaml
 
 from shogun import logger
 
@@ -20,7 +20,7 @@ class Aligner:
         check, msg = self.check_database(database_dir)
 
         with open(os.path.join(database_dir, 'metadata.yaml')) as stream:
-            self.data_files = load(stream)
+            self.data_files = yaml.load(stream, Loader=yaml.SafeLoader)
 
         if not check:
             raise Exception("Database %s is not formatted correctly: %s" % (database_dir, msg))
@@ -37,7 +37,7 @@ class Aligner:
     @classmethod
     def check_database(cls, dir):
         with open(os.path.join(dir, 'metadata.yaml'), 'r') as stream:
-            data_files = load(stream)
+            data_files = yaml.load(stream, Loader=yaml.SafeLoader)
 
         SUFFICES = {
             'burst': ['.edx'],

--- a/shogun/function/tests/test_function.py
+++ b/shogun/function/tests/test_function.py
@@ -9,7 +9,7 @@ import tempfile
 import unittest
 
 import pkg_resources
-from yaml import load
+import yaml
 
 from shogun.__main__ import _function
 from shogun.function import parse_function_db
@@ -26,7 +26,7 @@ class TestFunctionCheck(unittest.TestCase):
     def test_check_database(self):
         database = pkg_resources.resource_filename('shogun.tests', os.path.join('data'))
         with open(os.path.join(database, 'metadata.yaml'), 'r') as stream:
-            data_files = load(stream)
+            data_files = yaml.load(stream, Loader=yaml.SafeLoader)
         results = parse_function_db(data_files, database)
         self.assertTrue(results is not None)
 

--- a/shogun/utils/__init__.py
+++ b/shogun/utils/__init__.py
@@ -4,9 +4,9 @@ Copyright 2015-2017 Knights Lab, Regents of the University of Minnesota.
 This software is released under the GNU Affero General Public License (AGPL) v3.0 License.
 """
 
-from .last_common_ancestor import build_lca_map
+from .last_common_ancestor import build_lca_map, least_common_ancestor
 from .normalize import normalize_by_median_depth
 from ._utils import run_command, hash_file, read_checksums, save_csr_matrix, load_csr_matrix, read_fasta, convert_to_relative_abundance
 
 __all__ = ['build_lca_map', 'run_command', 'hash_file', 'read_checksums', 'save_csr_matrix', 'load_csr_matrix',
-           'normalize_by_median_depth', 'read_fasta', 'convert_to_relative_abundance']
+           'normalize_by_median_depth', 'read_fasta', 'convert_to_relative_abundance', 'least_common_ancestor']

--- a/shogun/utils/last_common_ancestor.py
+++ b/shogun/utils/last_common_ancestor.py
@@ -31,9 +31,9 @@ def build_lca_map(gen: typing.Iterator, tree: Taxonomy) -> dict:
 
 
 def least_common_ancestor(taxa_set):
+    lca = []
     taxa_set = [_.split(';') for _ in taxa_set]
-    for i, level in enumerate(reversed(list(zip(*taxa_set)))):
-        if len(set(level)) == 1:
-            convert_i = lambda x: None if x == 0 else -x
-            return ';'.join([taxon_level[0] for taxon_level in list(zip(*taxa_set))[:convert_i(i)]])
-    return None
+    for level in zip(*taxa_set):
+        if len(set(level)) > 1 or any(_.endswith('__') for _ in level):
+            return ';'.join(lca) if lca else None
+        lca.append(level[0])

--- a/shogun/utils/tests/test_utils.py
+++ b/shogun/utils/tests/test_utils.py
@@ -8,7 +8,7 @@ import unittest
 import pandas as pd
 import numpy as np
 
-from shogun.utils import convert_to_relative_abundance
+from shogun.utils import convert_to_relative_abundance, least_common_ancestor
 
 class TestRelativeAbundance(unittest.TestCase):
     def test_convert_relative_abundance(self):
@@ -17,3 +17,48 @@ class TestRelativeAbundance(unittest.TestCase):
         df_ra = convert_to_relative_abundance(df)
         pd.testing.assert_frame_equal(df_ra, df_expected)
 
+
+class TestLeastCommonAncestor(unittest.TestCase):
+    def test_least_common_ancestor(self):
+        # normal scenario
+        taxa = [
+            'k__Bacteria;p__Firmicutes;c__Clostridia;o__Clostridiales;f__Clostridiaceae;g__Clostridium;s__Clostridium acetobutylicum',
+            'k__Bacteria;p__Firmicutes;c__Clostridia;o__Clostridiales;f__Clostridiaceae;g__Clostridium;s__Clostridium botulinum',
+            'k__Bacteria;p__Firmicutes;c__Clostridia;o__Clostridiales;f__Clostridiaceae;g__Clostridium;s__Clostridium aldrichii',
+            'k__Bacteria;p__Firmicutes;c__Clostridia;o__Clostridiales;f__Clostridiaceae;g__Caminicella;s__Caminicella sporogenes'
+        ]
+        obs = least_common_ancestor(taxa)
+        exp = 'k__Bacteria;p__Firmicutes;c__Clostridia;o__Clostridiales;f__Clostridiaceae'
+        self.assertEqual(obs, exp)
+
+        # scenario 1: lowest level is unclassified
+        taxa = [
+            'k__Bacteria;p__Deinococcus-Thermus;c__Deinococci;o__Thermales;f__Thermaceae;g__Thermus;s__Thermus thermophilus;t__',
+            'k__Bacteria;p__Deinococcus-Thermus;c__Deinococci;o__Deinococcales;f__Deinococcaceae;g__Deinococcus;s__Deinococcus radiodurans;t__',
+            'k__Bacteria;p__Firmicutes;c__Clostridia;o__Clostridiales;f__Clostridiaceae;g__Clostridium;s__Clostridium acetobutylicum;t__',
+            'k__Bacteria;p__Firmicutes;c__Clostridia;o__Clostridiales;f__Clostridiaceae;g__Clostridium;s__Clostridium botulinum;t__'
+        ]
+        obs = least_common_ancestor(taxa)
+        exp = 'k__Bacteria'
+        self.assertEqual(obs, exp)
+
+        # scenario 2: middle level is unclassified
+        taxa = [
+            'k__Viruses;p__ssDNA_viruses;c__Geminiviridae;o__;f__;g__Begomovirus;s__Sida_mosaic_Sinaloa_virus',
+            'k__Viruses;p__ssDNA_viruses;c__Geminiviridae;o__;f__;g__Mastrevirus;s__Panicum_streak_virus',
+            'k__Viruses;p__ssDNA_viruses;c__Geminiviridae;o__;f__;g__Begomovirus;s__Cotton_leaf_crumple_virus',
+            'k__Viruses;p__ssDNA_viruses;c__Nanoviridae;o__;f__;g__Babuvirus;s__Banana_bunchy_top_virus'
+        ]
+        obs = least_common_ancestor(taxa)
+        exp = 'k__Viruses;p__ssDNA_viruses'
+        self.assertEqual(obs, exp)
+
+        # scenario 3: top level is inconsistent
+        taxa = [
+            'k__Bacteria;p__Proteobacteria;c__Gammaproteobacteria;o__Vibrionales;f__Vibrionaceae;g__Vibrio;s__Vibrio_tasmaniensis;t__Vibrio_tasmaniensis_LGP32',
+            'k__Bacteria;p__Proteobacteria;c__Gammaproteobacteria;o__Vibrionales;f__Vibrionaceae;g__Vibrio;s__Vibrio_maritimus;t__',
+            'k__Bacteria;p__Proteobacteria;c__Gammaproteobacteria;o__Vibrionales;f__Vibrionaceae;g__Aliivibrio;s__Aliivibrio_wodanis;t__',
+            'k__BacteriaPlasmid;p__Proteobacteria;c__Gammaproteobacteria;o__Vibrionales;f__Vibrionaceae;g__Aliivibrio;s__Aliivibrio_wodanis;t__'
+        ]
+        obs = least_common_ancestor(taxa)
+        self.assertIsNone(obs)


### PR DESCRIPTION
Hi @fedarko , as we discussed, here is one of the patches to SHOGUN. If fixes the LCA (lowest common ancestor) function. I demonstrated below how it works and why it is different from original:

Original function
```python
def least_common_ancestor(taxa_set):
    taxa_set = [_.split(';') for _ in taxa_set]
    for i, level in enumerate(reversed(list(zip(*taxa_set)))):
        if len(set(level)) == 1:
            convert_i = lambda x: None if x == 0 else -x
            return ';'.join([taxon_level[0] for taxon_level in list(zip(*taxa_set))[:convert_i(i)]])
    return None
```

Improved function
```python
def least_common_ancestor_rev(taxa_set):
    lca = []
    taxa_set = [_.split(';') for _ in taxa_set]
    for level in zip(*taxa_set):
        if len(set(level)) > 1 or any(_.endswith('__') for _ in level):
            return ';'.join(lca) if lca else None
        lca.append(level[0])
```
***
Scenario 1: Lowest level is unclassified.
```python
taxa = [
    'k__Bacteria;p__Deinococcus-Thermus;c__Deinococci;o__Thermales;f__Thermaceae;g__Thermus;s__Thermus thermophilus;t__',
    'k__Bacteria;p__Deinococcus-Thermus;c__Deinococci;o__Deinococcales;f__Deinococcaceae;g__Deinococcus;s__Deinococcus radiodurans;t__',
    'k__Bacteria;p__Firmicutes;c__Clostridia;o__Clostridiales;f__Clostridiaceae;g__Clostridium;s__Clostridium acetobutylicum;t__',
    'k__Bacteria;p__Firmicutes;c__Clostridia;o__Clostridiales;f__Clostridiaceae;g__Clostridium;s__Clostridium botulinum;t__'
]
```

```python
print(least_common_ancestor(taxa))
```
k__Bacteria;p__Deinococcus-Thermus;c__Deinococci;o__Thermales;f__Thermaceae;g__Thermus;s__Thermus thermophilus;t__

```python
print(least_common_ancestor_rev(taxa))
```
k__Bacteria

***
Scenario 2: Middle level is unclassified.
```python
taxa = [
    'k__Viruses;p__ssDNA_viruses;c__Geminiviridae;o__;f__;g__Begomovirus;s__Sida_mosaic_Sinaloa_virus',
    'k__Viruses;p__ssDNA_viruses;c__Geminiviridae;o__;f__;g__Mastrevirus;s__Panicum_streak_virus',
    'k__Viruses;p__ssDNA_viruses;c__Geminiviridae;o__;f__;g__Begomovirus;s__Cotton_leaf_crumple_virus',
    'k__Viruses;p__ssDNA_viruses;c__Nanoviridae;o__;f__;g__Babuvirus;s__Banana_bunchy_top_virus'
]
```
```python
print(least_common_ancestor(taxa))
```
k__Viruses;p__ssDNA_viruses;c__Geminiviridae;o__;f__
```python
print(least_common_ancestor_rev(taxa))
```
k__Viruses;p__ssDNA_viruses

***
Scenario 3: Top level is inconsistent.

```python
taxa = [
    'k__Bacteria;p__Proteobacteria;c__Gammaproteobacteria;o__Vibrionales;f__Vibrionaceae;g__Vibrio;s__Vibrio_tasmaniensis;t__Vibrio_tasmaniensis_LGP32',
    'k__Bacteria;p__Proteobacteria;c__Gammaproteobacteria;o__Vibrionales;f__Vibrionaceae;g__Vibrio;s__Vibrio_maritimus;t__',
    'k__Bacteria;p__Proteobacteria;c__Gammaproteobacteria;o__Vibrionales;f__Vibrionaceae;g__Aliivibrio;s__Aliivibrio_wodanis;t__',
    'k__BacteriaPlasmid;p__Proteobacteria;c__Gammaproteobacteria;o__Vibrionales;f__Vibrionaceae;g__Aliivibrio;s__Aliivibrio_wodanis;t__'
]
```
```python
print(least_common_ancestor(taxa))
```
k__Bacteria;p__Proteobacteria;c__Gammaproteobacteria;o__Vibrionales;f__Vibrionaceae
```python
print(least_common_ancestor_rev(taxa))
```
None
